### PR TITLE
Support projects without client

### DIFF
--- a/ClockifyAPI.py
+++ b/ClockifyAPI.py
@@ -326,10 +326,15 @@ class ClockifyAPI:
             self._loadUser(manager)
                    
         wsId = self.getWorkspaceID(workspace)
-        clId = self.getClientID(client, workspace)
+        clId = None
+        if not client is None:
+            clId = self.getClientID(client, workspace)
         url = self.url + "/workspaces/%s/projects"%wsId
-        params = {"name":name, "clientId": clId, "isPublic": isPublic, 
+        params = {"name":name, "isPublic": isPublic,
                   "billable": billable, "color": color}
+        if not clId is None:
+            params["clientId"] = clId
+
         if memberships != None:
             params["memberships"] = memberships.getData()
         if hourlyRate != None:

--- a/Clue.py
+++ b/Clue.py
@@ -89,7 +89,9 @@ class Clue:
             name = p["name"]
             if name not in clockifyPrjNames:
                 err = False
-                clientName = self.toggl.getClientName(p["cid"], workspace)
+                clientName = None
+                if "cid" in p:
+                    clientName = self.toggl.getClientName(p["cid"], workspace)
                 isPublic = not p["is_private"]
                 billable = p["billable"]
                 color = p["hex_color"]


### PR DESCRIPTION
Both, toggl and clockify, support projects which are not assigned to a
client. Allow migrating these, by omitting the clientId field in the add
project clockify api call in case no client is assigned to the project.