### PR TITLE
syncProjectsArchive: Fix usage of unassigned variable

### DIFF
--- a/Clue.py
+++ b/Clue.py
@@ -159,8 +159,8 @@ be no admin in clockify. Check your workspace settings and grant admin rights to
         numSkips = 0
         numErr = 0
         for p in prjs:
+            name = p["name"]
             if p["active"] == False:
-                name = p["name"]
                 self.logger.info("project %s is not active, trying to archive (%d of %d)"%(name, idx, numPrjs))
                 rv = self.clockify.archiveProject(name, workspace)
                 if rv == ClockifyAPI.RetVal.OK:


### PR DESCRIPTION
The log message for skipping active projects in the archiving loop uses
the name variable, which was not assigned in this case.