### PR TITLE
Features and fixes

### DIFF
--- a/ClockifyAPI.py
+++ b/ClockifyAPI.py
@@ -492,6 +492,7 @@ class ClockifyAPI:
 #                            self.logger.info("entry diff @userID: %s %s"%(str(self.userID), str(d['userId'])))
                         if tagNames != None:
                             tagIdsRcv = d["tagIds"]
+                            tagIdsRcv = tagIdsRcv if tagIdsRcv != None else []
                             tagNamesRcv = []
                             for tagID in tagIdsRcv:
                                 tagNamesRcv.append(self.getTagName(tagID, workspace))
@@ -510,7 +511,7 @@ class ClockifyAPI:
                         data = rv.json()
                         rv = RetVal.OK
                     else:
-                        self.logger.warning("Error adding time entrs, status code=%d, msg=%s"%(rv.status_code, rv.reason))
+                        self.logger.warning("Error adding time entrs, status code=%d, msg=%s"%(rv.status_code, rv.text))
                         rv = RetVal.ERR
                 else:
                     rv = RetVal.EXISTS
@@ -604,7 +605,7 @@ class ClockifyAPI:
             self._syncProjects = True
             return RetVal.OK
         else:
-            self.logger.warning("Error deleteProjet, status code=%d, msg=%s"%(rv.status_code, rv.reason))
+            self.logger.warning("Error deleteProject, status code=%d, msg=%s"%(rv.status_code, rv.reason))
             return RetVal.ERR
         
     def deleteAllProjects(self, workspace):

--- a/Clue.py
+++ b/Clue.py
@@ -229,8 +229,10 @@ be no admin in clockify. Check your workspace settings and grant admin rights to
             self._numEntries += len(entries)
     
     
-    def syncEntries(self, workspace, startTime, skipInvTogglUsers=False):
-        until = datetime.datetime.now()
+    def syncEntries(self, workspace, startTime, skipInvTogglUsers=False, until=None):
+        if until is None:
+            until = datetime.datetime.now()
+
         self._idx = 0
         self._numSkips = 0
         self._numOk = 0


### PR DESCRIPTION
In the course of using toggl2clockify I accumulated a few tweaks that were needed to smooth out the migration of our team to Clockify. These changes include:

* Prevents crash when  `tadIdsRcv == None` during a migration
* Adds feature to read `EndTime` from config file and import entries only up until that time
* Adds feature to delete time entries for a list of users supplied in the arguments
* Made Clockify API failures log the full text output from api rather than just the http error code which was helpful in debugging a failed migration.
* Fixed spelling error

Thanks for providing toggl2clockify! 